### PR TITLE
bump ssb-meta-feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "rimraf": "^3.0.2",
     "secret-stack": "^6.4.0",
     "ssb-caps": "^1.1.0",
-    "ssb-meta-feeds": "^0.10.0",
+    "ssb-meta-feeds": "^0.14.0",
     "ssb-validate": "^4.1.4",
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",

--- a/test/resolveIndexFeed.js
+++ b/test/resolveIndexFeed.js
@@ -29,18 +29,22 @@ test('Base', (t) => {
   const msg2 = { type: 'vote', vote: { value: 1, link: '%abc' } }
   const msg3 = { type: 'post', text: 'c' }
 
-  sbot.metafeeds.metafeed.getOrCreate((err, mf) => {
-    mf.getOrCreateFeed(
-      'index',
-      'classic',
+  sbot.metafeeds.findOrCreate((err, mf) => {
+    sbot.metafeeds.create(
+      mf,
       {
-        query: JSON.stringify({
-          op: 'and',
-          args: [
-            { op: 'type', string: 'contact' },
-            { op: 'author', feed: sbot.id },
-          ],
-        }),
+        feedpurpose: 'index',
+        feedformat: 'classic',
+        metadata: {
+          querylang: 'ssb-ql-1',
+          query: JSON.stringify({
+            op: 'and',
+            args: [
+              { op: 'type', string: 'contact' },
+              { op: 'author', feed: sbot.id },
+            ],
+          }),
+        },
       },
       (err, indexFeed) => {
         sbot.db.publish(msg1, (err, indexMsg) => {


### PR DESCRIPTION
This library was using `ssb-meta-feeds@0.10.0` which in turn was using the `publishAsMetafeeds` branch of ssb-db2 that was recently deleted, so when I did an npm install, it couldn't install.

So I updated `ssb-meta-feeds` to 0.14.0 and it broke the tests because the public API was a bit different, so I fixed that too.