### PR TITLE
add more checks in resolveIndexFeed

### DIFF
--- a/test/resolveIndexFeed-ql0.js
+++ b/test/resolveIndexFeed-ql0.js
@@ -67,7 +67,7 @@ test('resolveIndexFeed() QL0 Error cases', (t) => {
   pull(
     sbot.resolveIndexFeed(sbot.id),
     pull.collect((err, results) => {
-      t.match(err.message, /Not a proper index feed/, 'err')
+      t.match(err.message, /Index feed was not found/, 'err')
       t.equal(results.length, 0, 'zero results')
 
       pull(
@@ -75,7 +75,7 @@ test('resolveIndexFeed() QL0 Error cases', (t) => {
           '@randoIzFW+BvLV246CW05g6jLkTvLilp7IW+9irQkfU=.ed25519'
         ),
         pull.collect((err, results) => {
-          t.match(err.message, /Not a proper index feed/, 'err')
+          t.match(err.message, /Index feed was not found/, 'err')
           t.equal(results.length, 0, 'zero results')
 
           sbot.close(t.end)


### PR DESCRIPTION
In `resolveIndexFeed`, replaces `sbot.metafeeds.query.getMetadata` with `sbot.metafeeds.find`, and this turns out to lift a couple previously-hidden issues. E.g. we need to find the index `idx` under `rootMF -> indexesMF -> idx`. This broke one test that assumed `rootMF -> idx`. Overall I think it's good that we check that `idx` exists in the hierarchy where it should exist.

(Pending on #6 merged first)