### PR TITLE
use non-dedicated indexes from queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,8 +74,8 @@ exports.init = function (sbot, config) {
 
         const matchesQuery =
           querylang === 'ssb-ql-0'
-            ? QL0.toOperator(QL0.parse(query))
-            : QL1.toOperator(QL1.parse(query))
+            ? QL0.toOperator(QL0.parse(query), false)
+            : QL1.toOperator(QL1.parse(query), false)
 
         sbot.db.query(
           where(matchesQuery),
@@ -119,7 +119,9 @@ exports.init = function (sbot, config) {
     }
 
     const matchesQuery =
-      querylang === 'ssb-ql-0' ? QL0.toOperator(query) : QL1.toOperator(query)
+      querylang === 'ssb-ql-0'
+        ? QL0.toOperator(query, false)
+        : QL1.toOperator(query, false)
 
     return pull(
       sbot.db.query(

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pull-stream": "^3.6.14",
     "ssb-db2": "^2.4.0",
     "ssb-ref": "^2.16.0",
-    "ssb-subset-ql": "^0.2.1"
+    "ssb-subset-ql": "^0.3.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",
@@ -24,8 +24,8 @@
     "rimraf": "^3.0.2",
     "secret-stack": "^6.4.0",
     "ssb-caps": "^1.1.0",
-    "ssb-index-feed-writer": "^0.3.0",
-    "ssb-meta-feeds": "^0.18.1",
+    "ssb-index-feed-writer": "^0.3.2",
+    "ssb-meta-feeds": "^0.18.2",
     "ssb-validate": "^4.1.4",
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",


### PR DESCRIPTION
Protect both remote RPCs from vulnerabilities like #9 