### PR TITLE
error cases in getSubset should be pull.error()

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,16 +112,30 @@ exports.init = function (sbot, config) {
     if (!opts) opts = {}
     const querylang = opts.querylang
     if (!querylang) {
-      throw new Error('getSubset() is missing opts.querylang')
+      return pull.error(new Error('getSubset() is missing opts.querylang'))
     }
     if (querylang !== 'ssb-ql-0' && querylang !== 'ssb-ql-1') {
-      throw new Error('Unknown querylang: ' + querylang)
+      return pull.error(new Error('Unknown querylang: ' + querylang))
+    }
+
+    if (querylang === 'ssb-ql-0') {
+      try {
+        QL0.validate(query)
+      } catch (err) {
+        return pull.error(err)
+      }
+    } else {
+      try {
+        QL1.validate(query)
+      } catch (err) {
+        return pull.error(err)
+      }
     }
 
     const matchesQuery =
       querylang === 'ssb-ql-0'
-        ? QL0.toOperator(query, false)
-        : QL1.toOperator(query, false)
+        ? QL0.toOperator(QL0.parse(query), false)
+        : QL1.toOperator(QL1.parse(query), false)
 
     return pull(
       sbot.db.query(

--- a/index.js
+++ b/index.js
@@ -117,25 +117,14 @@ exports.init = function (sbot, config) {
     if (querylang !== 'ssb-ql-0' && querylang !== 'ssb-ql-1') {
       return pull.error(new Error('Unknown querylang: ' + querylang))
     }
-
-    if (querylang === 'ssb-ql-0') {
-      try {
-        QL0.validate(query)
-      } catch (err) {
-        return pull.error(err)
-      }
-    } else {
-      try {
-        QL1.validate(query)
-      } catch (err) {
-        return pull.error(err)
-      }
+    const ql = querylang === 'ssb-ql-0' ? QL0 : QL1
+    try {
+      ql.validate(query)
+    } catch (err) {
+      return pull.error(err)
     }
 
-    const matchesQuery =
-      querylang === 'ssb-ql-0'
-        ? QL0.toOperator(QL0.parse(query), false)
-        : QL1.toOperator(QL1.parse(query), false)
+    const matchesQuery = ql.toOperator(ql.parse(query), false)
 
     return pull(
       sbot.db.query(

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pull-stream": "^3.6.14",
     "ssb-db2": "^2.4.0",
     "ssb-ref": "^2.16.0",
-    "ssb-subset-ql": "~0.4.0"
+    "ssb-subset-ql": "~0.5.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",
@@ -24,7 +24,7 @@
     "rimraf": "^3.0.2",
     "secret-stack": "^6.4.0",
     "ssb-caps": "^1.1.0",
-    "ssb-index-feed-writer": "^0.3.2",
+    "ssb-index-feed-writer": "^0.3.4",
     "ssb-meta-feeds": "^0.18.2",
     "ssb-validate": "^4.1.4",
     "tap-bail": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pull-stream": "^3.6.14",
     "ssb-db2": "^2.4.0",
     "ssb-ref": "^2.16.0",
-    "ssb-subset-ql": "^0.3.0"
+    "ssb-subset-ql": "~0.4.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",

--- a/test/subset-ql1.js
+++ b/test/subset-ql1.js
@@ -49,6 +49,20 @@ test('getSubset() QL1 Base', (t) => {
   )
 })
 
+test('getSubset() QL1 string input', (t) => {
+  pull(
+    sbot.getSubset(
+      JSON.stringify({ op: 'type', string: 'post' }), // "type('post')"
+      { querylang: 'ssb-ql-1' }
+    ),
+    pull.collect((err, results) => {
+      t.error(err)
+      t.equal(results.length, 2, 'correct number of results')
+      t.end()
+    })
+  )
+})
+
 test('getSubset() QL1 Advanced', (t) => {
   pull(
     sbot.getSubset(
@@ -141,41 +155,41 @@ test('getSubset() QL1 Opts', (t) => {
 })
 
 test('getSubset() QL1 Error cases', (t) => {
-  t.throws(() => {
-    pull(
-      sbot.getSubset(
-        {
-          op: 'andz',
-          args: [
-            { op: 'type', string: 'post' },
-            { op: 'author', feed: sbot.id },
-          ],
-        },
-        {
-          querylang: 'ssb-ql-1',
-          descending: true,
-          pageSize: 1,
-        }
-      ),
-      pull.collect((err, results) => {})
-    )
-  }, 'unknown op andz')
+  t.plan(4)
 
-  t.throws(() => {
-    pull(
-      sbot.getSubset(
-        {
-          op: 'author',
-        },
-        { querylang: 'ssb-ql-1' }
-      ),
-      pull.collect((err, results) => {
-        console.log(err)
+  pull(
+    sbot.getSubset(
+      {
+        op: 'andz',
+        args: [
+          { op: 'type', string: 'post' },
+          { op: 'author', feed: sbot.id },
+        ],
+      },
+      {
+        querylang: 'ssb-ql-1',
+        descending: true,
+        pageSize: 1,
+      }
+    ),
+    pull.collect((err, results) => {
+      t.match(err.message, /Unknown "op" field/)
+      t.equals(results.length, 0)
+    })
+  )
 
-        sbot(t.end)
-      })
-    )
-  }, 'missing data')
+  pull(
+    sbot.getSubset(
+      { op: 'author', feed: sbot.id },
+      { querylang: 'ssb-ql-2000' }
+    ),
+    pull.collect((err, results) => {
+      t.match(err.message, /Unknown querylang/)
+      t.equals(results.length, 0)
+    })
+  )
+})
 
+test('teardown', (t) => {
   sbot.close(t.end)
 })


### PR DESCRIPTION
`getSubset` is a muxrpc API intended for remote peers, so `throw new Error` is not the right solution (I think it's not going to properly propagate the errors to the remote peer). Instead, this function is supposed to always return a pull-stream source, so we use `pull.error()` to do that.

Also updates ssb-subset-ql so that we can call `QL1.validate()` as an additional error checking step.

Reviewing commit-by-commit may be easiest.