### PR TITLE
rename this module to ssb-subset-rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,33 @@
-# SSB meta feeds RPC
+# SSB Subset RPC
 
-A secret stack plugin adding meta feeds subset replication related
-RPCs.
-
-Requires the
-[ssb-meta-feeds](https://github.com/ssb-ngi-pointer/ssb-meta-feeds)
-module loaded as a secret stack plugin.
+A secret stack plugin with an RPC to fetch message subsets.
 
 Implements the
 [spec](https://github.com/ssb-ngi-pointer/ssb-subset-replication-spec)
 
-# API
+## Installation
 
-## getSubset
+**Prerequisites:**
+
+- Requires **Node.js 10** or higher
+- Requires `ssb-db2`
+
+```
+npm install --save ssb-subset-rpc
+```
+
+Add this plugin like this:
+
+```diff
+ const sbot = SecretStack({ appKey: caps.shs })
+     .use(require('ssb-db2'))
++    .use(require('ssb-subset-rpc'))
+     // ...
+```
+
+## API
+
+### getSubset
 
 examples:
 
@@ -46,3 +61,7 @@ pull(
   })
 )
 ```
+
+## License
+
+LGPL-3.0

--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ exports.permissions = {
 }
 
 exports.init = function (sbot, config) {
+  if (!sbot.db || !sbot.db.query) {
+    throw new Error('ssb-subset-rpc requires ssb-db2')
+  }
+
   sbot.getSubset = function getSubset(query, opts) {
     if (!opts) opts = {}
     const querylang = opts.querylang

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "ssb-meta-feeds-rpc",
-  "description": "secret stack plugin with meta subset replication related RPCs",
+  "name": "ssb-subset-rpc",
+  "description": "secret stack plugin with an RPC to fetch message subsets",
   "version": "0.2.0",
-  "homepage": "https://github.com/ssb-ngi-pointer/ssb-meta-feeds-rpc",
+  "homepage": "https://github.com/ssb-ngi-pointer/ssb-subset-rpc",
   "repository": {
     "type": "git",
-    "url": "git://github.com/ssb-ngi-pointer/ssb-meta-feeds-rpc.git"
+    "url": "git://github.com/ssb-ngi-pointer/ssb-subset-rpc.git"
   },
   "files": [
     "*.js"
@@ -32,6 +32,9 @@
     "test": "tape test/*.js | tap-bail | tap-spec",
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\""
+  },
+  "engines": {
+    "node": ">=10"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
After merged, I'll deprecate npm `ssb-meta-feeds-rpc` and publish a new package under the new name.